### PR TITLE
Don't check prototypes on CallExpressions

### DIFF
--- a/lib/rules/no-function-prototype-extension-calls.js
+++ b/lib/rules/no-function-prototype-extension-calls.js
@@ -12,10 +12,8 @@ module.exports = function(context) {
   return {
     'CallExpression': function(node) {
       if (
-        node.callee.object && (
-          node.callee.object.type === 'FunctionExpression' ||
-          node.callee.object.type === 'CallExpression'
-        ) &&
+        node.callee.object &&
+        node.callee.object.type === 'FunctionExpression' &&
         extensionFixes.hasOwnProperty(node.callee.property.name)) {
 
         context.report({

--- a/tests/lib/rules/no-function-prototype-extension-calls.js
+++ b/tests/lib/rules/no-function-prototype-extension-calls.js
@@ -11,7 +11,13 @@ ruleTester.run("no-function-prototype-extension-calls", rule, {
   }, {
     code: "computed(function() {}).volatile()"
   }, {
-    code: "(function() {}).bind(this)"
+    code: "(function() {}.bind(this))"
+  }, {
+    code: "obj.method().on('arg')"
+  }, {
+    code: "func().on()"
+  }, {
+    code: "computed(function() {}).property()"
   }],
 
   invalid: [{
@@ -28,9 +34,6 @@ ruleTester.run("no-function-prototype-extension-calls", rule, {
     errors: ["Avoid using function prototype extensions like 'on'. Use the on('event', function() {}) syntax instead."]
   }, {
     code: "(function() {}.property())",
-    errors: ["Avoid using function prototype extensions like 'property'. Use the computed('dependentKey', function() {}) syntax instead."]
-  }, {
-    code: "computed(function() {}).property()",
     errors: ["Avoid using function prototype extensions like 'property'. Use the computed('dependentKey', function() {}) syntax instead."]
   }]
 });


### PR DESCRIPTION
I believe the original rule was too aggressive by checking all CallExpressions. 

With this change we loose the error on this example:

``` js
computed(function() {}).property()
```

But we get the opportunity to use the restricted names (including `on`) as methods.

cc @mixonic @rwjblue  
